### PR TITLE
Better aspect ratio support for sparks-from-fire.glsl

### DIFF
--- a/fireworks.glsl
+++ b/fireworks.glsl
@@ -4,7 +4,7 @@
 // License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
 // Email:countfrolic@gmail.com Twitter:@The_ArtOfCode
 
-#define BLACK_BLEND_THRESHOLD .4
+#define BLACK_BLEND_THRESHOLD .25
 #define PI 3.141592653589793238
 #define TWOPI 6.283185307179586
 #define S(x,y,z) smoothstep(x,y,z)
@@ -104,7 +104,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord)
         p.x *= 1.6;
         c += explosion(uv, p, id, et);
     }
-    c = Rainbow(c);
+    // c = Rainbow(c);
 
     vec2 termUV = fragCoord.xy / iResolution.xy;
     vec4 terminalColor = texture(iChannel0, termUV);

--- a/inside-the-matrix.glsl
+++ b/inside-the-matrix.glsl
@@ -7,6 +7,7 @@
   @pkazmier modified this shader to work in Ghostty.
 */
 
+#define BLACK_BLEND_THRESHOLD .25
 const int ITERATIONS = 40;   //use less value if you need more performance
 const float SPEED = .5;
 
@@ -405,9 +406,9 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
   	// Combine the matrix effect with the terminal color
   	// vec3 blendedColor = terminalColor.rgb + col;
 
-    // Make a mask that is 1.0 where the terminal content is not black
-    float mask = 1.2 - step(0.5, dot(terminalColor.rgb, vec3(1.0)));
-    vec3 blendedColor = mix(terminalColor.rgb * 1.2, col, mask);
+    // // Make a mask that is 1.0 where the terminal content is not black
+    float mask = 1.4 - step(0.4, dot(terminalColor.rgb, vec3(1.0)));
+    vec3 blendedColor = mix(terminalColor.rgb * 1.6, col, mask);
 
     fragColor = vec4(blendedColor, terminalColor.a);
 }

--- a/just-snow.glsl
+++ b/just-snow.glsl
@@ -29,7 +29,7 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
 	for (int i = 0; i < LAYERS; i++) {
 		float fi = float(i);
 		vec2 q =-uv*(1.0 + fi * DEPTH);
-		q += vec2(q.y * (WIDTH * mod(fi * 7.238917, 1.0) - WIDTH * 0.5), -SPEED * iTime / (1.0 + fi * DEPTH * 0.03));
+		q += vec2(q.y * (WIDTH * mod(fi * 7.238917, 1.0) - WIDTH * 0.5), SPEED * iTime / (1.0 + fi * DEPTH * 0.03));
 		vec3 n = vec3(floor(q), 31.189 + fi);
 		vec3 m = floor(n) * 0.00001 + fract(n);
 		vec3 mp = (31415.9 + m) / fract(p * m);

--- a/matrix-hallway.glsl
+++ b/matrix-hallway.glsl
@@ -6,11 +6,12 @@
 //
 // https://www.shadertoy.com/view/ldjBW1
 //
-#define GREEN_ALPHA .33
+#define BLACK_BLEND_THRESHOLD .25
+#define GREEN_ALPHA .15
 #define R fract(1e2*sin(p.x*8.+p.y))
 void mainImage(out vec4 o,vec2 u) {
   vec3 v=vec3(u,1)/iResolution-.5,
-  s=.8/abs(v),
+  s=.5/abs(v),
   i=ceil(8e2*(s.z=min(s.y,s.x))*(s.y<s.x?v.xzz:v.zyz)),
   j=fract(i*=.1),
   p=vec3(9,int(iTime*(9.+8.*sin(i-=j).x)),0)+i;
@@ -18,7 +19,7 @@ void mainImage(out vec4 o,vec2 u) {
 
   vec2 uv = u.xy / iResolution.xy;
   vec4 terminalColor = texture(iChannel0, uv);
-  float mask = 1.2 - step(0.5, dot(terminalColor.rgb, vec3(1.0)));
-  vec3 blendedColor = mix(terminalColor.rgb * 1.2, o.rgb, mask);
+  float alpha = step(length(terminalColor.rgb), BLACK_BLEND_THRESHOLD);
+  vec3 blendedColor = mix(terminalColor.rgb, o.rgb, alpha);
   o = vec4(blendedColor, terminalColor.a);
 }

--- a/matrix-hallway.glsl
+++ b/matrix-hallway.glsl
@@ -6,35 +6,19 @@
 //
 // https://www.shadertoy.com/view/ldjBW1
 //
-
-#define SPEED_MULTIPLIER 1.
 #define GREEN_ALPHA .33
+#define R fract(1e2*sin(p.x*8.+p.y))
+void mainImage(out vec4 o,vec2 u) {
+  vec3 v=vec3(u,1)/iResolution-.5,
+  s=.8/abs(v),
+  i=ceil(8e2*(s.z=min(s.y,s.x))*(s.y<s.x?v.xzz:v.zyz)),
+  j=fract(i*=.1),
+  p=vec3(9,int(iTime*(9.+8.*sin(i-=j).x)),0)+i;
+  o-=o,o.g=R/s.z;p*=j;o*=R>.5&&j.x<.6&&j.y<.8?GREEN_ALPHA:0.;
 
-#define BLACK_BLEND_THRESHOLD .4
-
-#define R fract(1e2 * sin(p.x * 8. + p.y))
-
-void mainImage(out vec4 fragColor, vec2 fragCoord) {
-    vec3 v = vec3(fragCoord, 1) / iResolution - .5;
-    // vec3 s = .5 / abs(v);
-    // scale?
-    vec3 s = .9 / abs(v);
-    s.z = min(s.y, s.x);
-    vec3 i = ceil( 8e2 * s.z * ( s.y < s.x ? v.xzz : v.zyz ) ) * .1;
-    vec3 j = fract(i);
-    i -= j;
-    vec3 p = vec3(9, int(iTime * SPEED_MULTIPLIER * (9. + 8. * sin(i).x)), 0) + i;
-    vec3 col = fragColor.rgb;
-    col.g = R / s.z;
-    p *= j;
-    col *= (R >.5 && j.x < .6 && j.y < .8) ? GREEN_ALPHA : 0.;
-
-  	// Sample the terminal screen texture including alpha channel
-    vec2 uv = fragCoord.xy / iResolution.xy;
-  	vec4 terminalColor = texture(iChannel0, uv);
-
-    float alpha = step(length(terminalColor.rgb), BLACK_BLEND_THRESHOLD);
-    vec3 blendedColor = mix(terminalColor.rgb * 1.2, col, alpha);
-
-    fragColor = vec4(blendedColor, terminalColor.a);
+  vec2 uv = u.xy / iResolution.xy;
+  vec4 terminalColor = texture(iChannel0, uv);
+  float mask = 1.2 - step(0.5, dot(terminalColor.rgb, vec3(1.0)));
+  vec3 blendedColor = mix(terminalColor.rgb * 1.2, o.rgb, mask);
+  o = vec4(blendedColor, terminalColor.a);
 }

--- a/sparks-from-fire.glsl
+++ b/sparks-from-fire.glsl
@@ -8,7 +8,8 @@
 #define SMOKE_ALPHA_MOD 0.5
 #define LAYERS_COUNT 8
 
-#define BLACK_BLEND_THRESHOLD .4
+// Looks best with tokyonight moon
+#define BLACK_BLEND_THRESHOLD .25
 
 #define VEC3_1 (vec3(1.0))
 

--- a/sparks-from-fire.glsl
+++ b/sparks-from-fire.glsl
@@ -212,7 +212,17 @@ vec3 layeredParticles(in vec2 uv, in float sizeMod, in float alphaMod, in int la
 }
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
-    vec2 uv = (2.0 * fragCoord - iResolution.xy) / iResolution.x;
+    //vec2 uv = (2.0 * fragCoord - iResolution.xy) / iResolution.x;
+
+    // 1) Find the smaller of (width, height)
+    float scale = min(iResolution.x, iResolution.y);
+
+    // 2) Center fragCoord so that (0,0) is in the middle of the screen
+    vec2 centered = fragCoord - 0.5 * iResolution.xy;
+
+    // 3) Divide by 'scale' so the effect is the same in both X and Y
+    //    This ensures shapes remain undistorted
+    vec2 uv = centered / scale; 
     
     // float vignette = 1.1 - smoothstep(0.4, 1.4, length(uv + vec2(0.0, 0.3)));
     float vignette = 1.3 - smoothstep(0.4, 1.4, length(uv + vec2(0.0, 0.3)));


### PR DESCRIPTION
The shader works well in wide aspect ratios but struggles in tall ones. This edit fixes this somewhat so that you can use tall windows.